### PR TITLE
Set HOME correctly under interactive sessions

### DIFF
--- a/lib/service/command_utils.rb
+++ b/lib/service/command_utils.rb
@@ -32,7 +32,7 @@ require_relative 'patches/unicode-display_width'
 
 module Service
   module CommandUtils
-    PRESERVE = ['flight_ROOT']
+    PRESERVE = ['flight_ROOT', 'USER', 'LOGNAME']
 
     class << self
       def run_script(name, script, dir, op, args = [], context = {}, env = {})
@@ -127,7 +127,7 @@ module Service
         end
         ENV.clear
         ENV['PATH'] = '/bin:/sbin:/usr/bin:/usr/sbin'
-        ENV['HOME'] = (Dir.home rescue '/')
+        ENV['HOME'] = (Dir.home(preserved_env['USER']) rescue '/')
         ENV.merge!(preserved_env)
         ENV.merge!(env)
         setup_bash_funcs(ENV, fileno)


### PR DESCRIPTION
`Dir.home` if called without an argument and without `USER` (and/or
`LOGNAME`) set in the environment will attempt to discover the login
user.  It does this by making a call to the C function `getlogin` (or
`getlogin_r`).  `getlogin` returns " the name of the user logged in on
the controlling terminal of the process, or a null pointer if this
information cannot be determined."

We have a number of uses cases for running `service start ...`.

1. `service start ...` is called from a process that doesn't have a
   controlling terminal, such as from a startup script.  `Dir.home()`
   (without `ENV['USER']` set) will raise an exception which is caught
   and `ENV['HOME']` is set to `/`.

2. A user SSHs into the node as `root` and runs `service start ...`.
   `Dir.home()` (without `ENV['USER']` set) determines the user of the
   controlling terminal to be `root` and returns their home directory.
   `ENV['HOME']` is set to `/`.

3. A user SSHs into the node as a non-root user, say `flight`, `sudo`s
   to `root` and runs `service start ...`.  `Dir.home()` (without
   `ENV['USER']` set) determines the user of the controlling terminal to
   be `flight` and returns their home directory.  `ENV['HOME']` is set
   to `/home/flight`.

We can provide consistent behaviour for all three cases by ensuring that 1)
`ENV['USER']` is preserved in the environment; and 2) passing
`ENV['USER']` to `Dir.home`.

I've also elected to preserve `ENV['LOGNAME']` as it is expected to have
the same value as `ENV['USER']`.