### PR TITLE
Prevent ncurses running in a non-interactive terminal

### DIFF
--- a/lib/service/commands/configure.rb
+++ b/lib/service/commands/configure.rb
@@ -37,7 +37,7 @@ module Service
       def run
         if !$stdout.tty? && !options.config
           raise InvalidInput, <<~ERROR.chomp
-            Can not continue within a non-interactive terminal!
+            Cannot continue within a non-interactive terminal!
             Please specify the configs with the following flag: #{Paint['--config JSON', :yellow]}
           ERROR
         end

--- a/lib/service/commands/configure.rb
+++ b/lib/service/commands/configure.rb
@@ -35,6 +35,13 @@ module Service
   module Commands
     class Configure < Command
       def run
+        if !$stdout.tty? && !options.config
+          raise InvalidInput, <<~ERROR.chomp
+            Can not continue within a non-interactive terminal!
+            Please specify the configs with the following flag: #{Paint['--config JSON', :yellow]}
+          ERROR
+        end
+
         if service.configurable?
           # Load the data either via the dialog or non-interactively
           data = if options.config


### PR DESCRIPTION
The service configure command will break the terminal if ran
non interactively. This causes issues with pipes

Instead the command errors and prompts for --config