### PR TITLE
Ensure USER is set when starting services

### DIFF
--- a/lib/service/command_utils.rb
+++ b/lib/service/command_utils.rb
@@ -125,6 +125,16 @@ module Service
         preserved_env = {}.tap do |h|
           PRESERVE.each {|k| h[k] = ENV[k]}
         end
+        # Some of our services don't like `USER` being absent.  Some service
+        # launchers, such as flight-plugin-system-systemd-service, don't set
+        # `USER`. We workaround these issues here.
+        if preserved_env['USER'].nil?  || preserved_env['USER'] == ""
+          preserved_env['USER'] = Etc.getpwuid(Process.uid).name
+        end
+        if preserved_env['LOGNAME'].nil? || preserved_env['LOGNAME'] == ""
+          preserved_env['LOGNAME'] = preserved_env['USER']
+        end
+
         ENV.clear
         ENV['PATH'] = '/bin:/sbin:/usr/bin:/usr/sbin'
         ENV['HOME'] = (Dir.home(preserved_env['USER']) rescue '/')


### PR DESCRIPTION
When the flight service stack is started by `flight-plugin-system-systemd-service`, the environment variable `USER` is not set.  This can cause some of our services to fail to start.  We work around this issue by determining `USER` from `Process.uid` and `Etc.getpwuid` if `USER` is blank.

Specifically, `flight-desktop-restapi` runs a `flight-desktop` version check command on boot which fails if `USER` is not set.  If it fails, `flight-desktop-restapi` fails to start.