### PR TITLE
Pass `--force` flag to stop.sh scripts

### DIFF
--- a/lib/service/type.rb
+++ b/lib/service/type.rb
@@ -122,7 +122,8 @@ module Service
     end
 
     def stop(force: false)
-      run_operation('stop', args: [pidfile])
+      args = [pidfile].tap { |a| a << "--force" if force }
+      run_operation('stop', args: args)
       sleep_whilst_running
       if force && running?
         kill_via_signal('TERM') || kill_via_signal('KILL')


### PR DESCRIPTION
Some service such as console-api might have a long-winded graceful shutdown mechanism built in.  Passing the `--force` flag should skip the graceful mechanism and kill the service ASAP.

This change allows the stop.sh script for console-api to perform a non-graceful shutdown when the `--force` flag is given.